### PR TITLE
Create a project state transition from online to successful

### DIFF
--- a/app/models/concerns/project/state_machine_handler.rb
+++ b/app/models/concerns/project/state_machine_handler.rb
@@ -42,6 +42,10 @@ module Project::StateMachineHandler
           project.expired? && project.pending_contributions_reached_the_goal?
         }
 
+        transition online: :successful, if: ->(project) {
+          project.expired? && project.reached_goal? && !project.in_time_to_wait?
+        }
+
         transition waiting_funds: :successful,  if: ->(project) {
           project.reached_goal? && !project.in_time_to_wait?
         }


### PR DESCRIPTION
When the online expired project has reached the goal, and there is no waiting confirmation contributions, the project should go straightforward from online to successful state